### PR TITLE
Add socket close behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -532,9 +532,9 @@
       }
     },
     "ilp-protocol-psk2": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/ilp-protocol-psk2/-/ilp-protocol-psk2-0.4.1.tgz",
-      "integrity": "sha512-6LOgwDyONdSWOoQYx6g8knvIwjdbrTnLbrV8p40JztjRvZqG4zKSKy5kSIoQRflYg1t7jTBMVHe9Z7qUEoRxYQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ilp-protocol-psk2/-/ilp-protocol-psk2-0.5.0.tgz",
+      "integrity": "sha512-VwxNI7ZpVLv7LKLrTnxVJxnq3WBgzX/TdJNc72RqoCU1jpo+hD0L1DKY4pGTr96bLfuZCAb7gi9ZySohwC1jeA==",
       "requires": {
         "bignumber.js": "5.0.0",
         "debug": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bignumber.js": "^6.0.0",
     "debug": "^3.1.0",
     "eventemitter3": "^3.0.1",
-    "ilp-protocol-psk2": "^0.4.1",
+    "ilp-protocol-psk2": "^0.5.0",
     "long": "^4.0.0",
     "oer-utils": "^1.3.4"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -804,10 +804,6 @@ function isSocketChunkData (packet: SocketClose | SocketChunkData): packet is So
   return packet.hasOwnProperty('amountExpected')
 }
 
-function serializeCloseMessage (): Buffer {
-  return Buffer.alloc(1, TYPE_CLOSE)
-}
-
 function serializeChunkData (chunkData: SocketChunkData): Buffer {
   const amountExpected = forceValueToBeBetween(chunkData.amountExpected, 0, MAX_UINT64)
   const amountWanted = forceValueToBeBetween(chunkData.amountWanted, 0, MAX_UINT64)


### PR DESCRIPTION
Probably resolves https://github.com/emschwartz/ilp-protocol-paystream/issues/1

This adds a close message to the protocol that will be sent when one side calls `socket.close()`. It isn't called automatically but the higher-level components that use this library can call it when they want to.

One open question is whether we should always have the close message sent as a separate unfulfillable, zero-amount request, or whether there should be a way to indicate that a certain (fulfillable) request is the last one.